### PR TITLE
fix build errors, now 3 RETERN_IF_ASYNERROR macros

### DIFF
--- a/CRYOSMSApp/src/CRYOSMSDriver.h
+++ b/CRYOSMSApp/src/CRYOSMSDriver.h
@@ -23,7 +23,7 @@ public:
 	double writeToDispConversion;
 	bool writeDisabled;
 	int testVar; //for use in google tests where functionality can not be tested with PV values
-	bool started = false;
+	bool started;
 	asynStatus procDb(std::string pvSuffix);
 	asynStatus getDb(std::string pvSuffix, void *pbuffer);
 	asynStatus putDb(std::string pvSuffix, const void *value);


### PR DESCRIPTION
Fixed build errors:
 - fixed trailing comma error in RETURN_IF_ASYNERROR when passed no variables for the function by making 3 separate versions taking 1, 2 and 3 arguments for the function
- initialised "started" better
- made 2010 happy with itterating through environment variable names