### PR TITLE
Fix dodgy quotation marks

### DIFF
--- a/cryosmsSup/cryosms.db
+++ b/cryosmsSup/cryosms.db
@@ -197,7 +197,7 @@ record(ai, "$(P)OUTPUT:PERSIST:RAW:UNIT")
 
 record(ai, "$(P)OUTPUT:RAW")
 {
-    field(DESC, "Raw value returned from the PSU, A or T")# returned during a “GO” command
+    field(DESC, "Raw value returned from the PSU, A or T")# returned during a "GO" command
     field(DTYP, "stream")
     field(INP, "@cryosms.proto getOutput($(P)) $(PORT)")
     field(PREC, "3")
@@ -210,7 +210,7 @@ record(ai, "$(P)OUTPUT:RAW")
 
 record(bi, "$(P)OUTPUT:RAW:UNIT")
 {
-    field(DESC, "The unit for OUTPUT:RAW") # returned as part of a “GO” command
+    field(DESC, "The unit for OUTPUT:RAW") # returned as part of a "GO" command
 }
 
 record(ao, "$(P)OUTPUT:SP")


### PR DESCRIPTION
The DbUnitChecker didn't run with python 3 because the encoding of this file was utf-8 and used quotation marks not parseable by the unit checker. This change makes it parseable.