### PR TITLE
corrected order of operations in checkTToA, conversions in tests

### DIFF
--- a/CRYOSMSApp/src/CRYOSMSDriver.cpp
+++ b/CRYOSMSApp/src/CRYOSMSDriver.cpp
@@ -148,9 +148,8 @@ asynStatus CRYOSMSDriver::checkTToA()
 	}
 	else try {
 		double teslaToAmps = std::stod(envVarMap.at("T_TO_A"));
-		RETURN_IF_ASYNERROR2(putDb, "CONSTANT:_SP", &teslaToAmps);
-
 		this->writeToDispConversion = unitConversion(1.0, envVarMap.at("WRITE_UNIT"), envVarMap.at("DISPLAY_UNIT"));
+		RETURN_IF_ASYNERROR2(putDb, "CONSTANT:_SP", &teslaToAmps);
 	}
 	catch (std::exception &e) {
 		errlogSevPrintf(errlogMajor, "Invalid value of T_TO_A provided");

--- a/CRYOSMSApp/src/tests/CRYOSMSTests.cc
+++ b/CRYOSMSApp/src/tests/CRYOSMSTests.cc
@@ -49,11 +49,11 @@ namespace {
 	INSTANTIATE_TEST_CASE_P(
 		TToATests, TToAParametrisedTests,
 		::testing::Values(
-			std::make_tuple("AMPS", "GAUSS", 50000.0), // 10,000/0.2
+			std::make_tuple("AMPS", "GAUSS", 2000.0), // 10,000 * 0.2
 			std::make_tuple("AMPS", "AMPS", 1.0),
-			std::make_tuple("AMPS", "TESLA", 5.0), // 1/0.2
+			std::make_tuple("AMPS", "TESLA", 0.2), // specified conversion, "T_TO_A" is a dividitave conversion factor, named "TO" per convention
 			std::make_tuple("TESLA", "GAUSS", 10000.0), //1T = 10,000G
-			std::make_tuple("TESLA", "AMPS", 0.2), //specified conversion
+			std::make_tuple("TESLA", "AMPS", 5.0), // 1/0.2
 			std::make_tuple("TESLA", "TESLA", 1.0)
 		)
 	);


### PR DESCRIPTION
fixed the reasons googletests were failing:

In CRYOSMSDriver.cpp, the logic to be tested  was placed after an attempt to write to a PV, which would always fail and return before getting to said logic (googletests don't start up the whole IOC, so no PVs)

In CRYOSMSTests.cc, needed to switch around the numbers for conversions. In the current version, the value in T_TO_A  was clarified as needing to be dividative (technichally T *per* A). The logic in the driver was changed to reflect this, however I neglected to follow through in the googletests