### PR TITLE
Ticket7294 fix compiler error

### DIFF
--- a/CRYOSMSApp/src/CRYOSMSDriver.cpp
+++ b/CRYOSMSApp/src/CRYOSMSDriver.cpp
@@ -64,8 +64,6 @@ return status; \
 }
 
 
-static const char *driverName = "CRYOSMSDriver"; ///< Name of driver for use in message printing 
-
 static void eventQueueThread(CRYOSMSDriver* drv);
 
 CRYOSMSDriver::CRYOSMSDriver(const char *portName, std::string devPrefix, std::map<std::string, std::string> argMap)

--- a/CRYOSMSApp/src/CRYOSMSDriver.cpp
+++ b/CRYOSMSApp/src/CRYOSMSDriver.cpp
@@ -56,6 +56,7 @@ if (status != asynSuccess)\
 std::ostringstream errString; \
 errString << "Error returned when calling " << #func << " with argument " << arg; \
 errlogSevPrintf(errlogMajor, errString.str().c_str()); \
+return status; \
 }
 
 #define RETURN_IF_ASYNERROR2(func, arg1, arg2) status = (func)(arg1, arg2); \

--- a/CRYOSMSApp/src/CRYOSMSDriver.cpp
+++ b/CRYOSMSApp/src/CRYOSMSDriver.cpp
@@ -1272,12 +1272,12 @@ extern "C"
 		std::string devPrefix = args[0].aval.av[2];
 
 		errlogSevPrintf(errlogInfo, "Loading macros into asyn driver:\n");
-		for (int i = 0; i < sizeof(envVarsNames) / sizeof(const char*); ++i)
+		for (std::size_t i = 0; i < sizeof(envVarsNames) / sizeof(const char*); ++i)
 		{
 			char * argValC = args[0].aval.av[i + 3];
 			std::string argVal = argValC;
 			std::string argName = envVarsNames[i];
-			errlogSevPrintf(errlogInfo, "%s: %s\n", envVarsNames[i], argVal);
+			errlogSevPrintf(errlogInfo, "%s: %s\n", envVarsNames[i], argValC);
 			std::pair<std::string, std::string > newPair(argName, argVal); // args starts with CRYOSMSConfigure, portName and devPrefix
 			argMap.insert(newPair);
 		}

--- a/CRYOSMSApp/src/CRYOSMSDriver.cpp
+++ b/CRYOSMSApp/src/CRYOSMSDriver.cpp
@@ -204,8 +204,7 @@ asynStatus CRYOSMSDriver::checkTToA()
 	}
 	catch (const std::exception& ex)
 	{
-		errlogSevPrintf(errlogFatal, ex.what());
-		errlogSevPrintf(errlogMajor, "Invalid value of T_TO_A provided");
+		errlogSevPrintf(errlogMajor, "Invalid value of T_TO_A provided: %s", ex.what());
 		const char *statMsg = "Invalid calibration from Tesla to Amps supplied";
 		this->writeDisabled = TRUE;
 		RETURN_IF_ASYNERROR2(putDb, "STAT", statMsg);
@@ -250,8 +249,7 @@ asynStatus CRYOSMSDriver::checkMaxVolt()
 		}
 		catch (const std::exception& ex)
 		{
-			errlogSevPrintf(errlogFatal, ex.what());
-			errlogSevPrintf(errlogMajor, "Invalid value of MAX_VOLT provided");
+			errlogSevPrintf(errlogMajor, "Invalid value of MAX_VOLT provided: %s", ex.what());
 		}
 	}
 	return status;

--- a/CRYOSMSApp/src/CRYOSMSDriver.cpp
+++ b/CRYOSMSApp/src/CRYOSMSDriver.cpp
@@ -1172,6 +1172,13 @@ void CRYOSMSDriver::startRamping(double rate, double target, int sign, RampType 
 		statMsg = "Ramping fast to zero";
 		putDb("FAST:ZERO", &trueVal);
 		break;
+	default:
+		errlogSevPrintf(errlogMajor, "Invalid ramp type requested, aborting queue");
+		statMsg = "Ramp Failing to initialise";
+		putDb("STAT", statMsg);
+		eventQueue.push_front(abortRampEvent(this));
+		atTarget = true;
+		return;
 	}
 
 	int signString = (sign == 1) ? 2 : 1; //sign is handled by mbbo with 0 = 0, 1 = negative, 2 = positive

--- a/CRYOSMSApp/src/CRYOSMSDriver.cpp
+++ b/CRYOSMSApp/src/CRYOSMSDriver.cpp
@@ -52,14 +52,14 @@ return status; \
 #define RETURN_IF_ASYNERROR1(func, arg) status = (func)(arg); \
 if (status != asynSuccess)\
 {\
-errlogSevPrintf(errlogMajor, "Error returned when calling %s with arguments %s", #func, arg);\
+errlogSevPrintf(errlogMajor, "Error returned when calling %s", #func);\
 return status; \
 }
 
 #define RETURN_IF_ASYNERROR2(func, arg1, arg2) status = (func)(arg1, arg2); \
 if (status != asynSuccess)\
 {\
-errlogSevPrintf(errlogMajor, "Error returned when calling %s with arguments %s", #func, arg1);\
+errlogSevPrintf(errlogMajor, "Error returned when calling %s", #func);\
 return status; \
 }
 

--- a/CRYOSMSApp/src/CRYOSMSDriver.h
+++ b/CRYOSMSApp/src/CRYOSMSDriver.h
@@ -80,9 +80,6 @@ public:
 	boost::msm::back::state_machine<cryosmsStateMachine> qsm;
 private:
 	std::string devicePrefix;
-
-#define FIRST_SMS_PARAM P_deviceName
-
 	int P_deviceName; // string
 	int P_initLogic;
 	int P_Rate; //float
@@ -92,9 +89,6 @@ private:
 	int P_abortRamp;
 	int P_outputModeSet;
 	int P_calcHeater; //int as above
-
-#define LAST_SMS_PARAM 	P_calcHeater
-#define NUM_SMS_PARAMS	(&LAST_SMS_PARAM - &FIRST_SMS_PARAM + 1)
 
 
 	std::vector<double> pRate_;

--- a/CRYOSMSApp/src/CRYOSMSDriver.h
+++ b/CRYOSMSApp/src/CRYOSMSDriver.h
@@ -47,10 +47,10 @@ public:
 	bool writeDisabled;
 	int testVar; //for use in google tests where functionality can not be tested with PV values
 	bool started;
-	bool fastRamp = false; //whether or not device is in "fast" mode, used exclusively to update "STAT" PV correctly
-	bool fastRampZero = false; //whether or not device is in "fast zero" mode, used exclusively to update "STAT" PV correctly
-	bool cooling = 0;//whether heater is cooling down
-	bool warming = 0;//whether heater is warming up
+	bool fastRamp; //whether or not device is in "fast" mode, used exclusively to update "STAT" PV correctly
+	bool fastRampZero; //whether or not device is in "fast zero" mode, used exclusively to update "STAT" PV correctly
+	bool cooling;//whether heater is cooling down
+	bool warming;//whether heater is warming up
 	int trueVal = 1; //Used in dbputs, as it needs to be passed ref to int
 	int falseVal = 0;//Used in dbputs, as it needs to be passed ref to int
 	asynStatus procDb(std::string pvSuffix);
@@ -66,7 +66,6 @@ public:
 	void checkForTarget();
 	void checkIfPaused();
 	void checkHeaterDone();
-	boost::msm::back::state_machine<cryosmsStateMachine> qsm;
 	void resumeRamp() override;
 	void pauseRamp() override;
 	void startRamping(double rate, double target, int rampDir, RampType rampType) override;
@@ -78,6 +77,7 @@ public:
 	void startWarming() override;
 	void reachTemp() override;
 	void preRampHeaterCheck() override;
+	boost::msm::back::state_machine<cryosmsStateMachine> qsm;
 private:
 	std::string devicePrefix;
 

--- a/CRYOSMSApp/src/QueuedStateMachine.h
+++ b/CRYOSMSApp/src/QueuedStateMachine.h
@@ -199,4 +199,4 @@ struct cryosmsStateMachine : public msm::front::state_machine_def<cryosmsStateMa
 		errlogSevPrintf(errlogMajor, "no transition from state %s on event %s", stateList[state].c_str(), typeid(e).name());
 	}
 };
-#endif !QUEUEDSTATEMACHINE_H
+#endif /* !QUEUEDSTATEMACHINE_H */

--- a/CRYOSMSApp/src/tests/CRYOSMSTests.cc
+++ b/CRYOSMSApp/src/tests/CRYOSMSTests.cc
@@ -55,7 +55,7 @@ namespace {
 		ASSERT_EQ(testDriver->writeToDispConversion, std::get<2>(GetParam()));
 	}
 
-	INSTANTIATE_TEST_CASE_P(
+	INSTANTIATE_TEST_SUITE_P(
 		TToATests, TToAParametrisedTests,
 		::testing::Values(
 			std::make_tuple("AMPS", "GAUSS", 2000.0), // 10,000 * 0.2
@@ -90,7 +90,7 @@ namespace {
 		static void TearDownTestCase() {}
 	};
 
-	INSTANTIATE_TEST_CASE_P(
+	INSTANTIATE_TEST_SUITE_P(
 		AllowPersistTests, AllowPersistParametrisedTests,
 		::testing::Values(
 			"FAST_FILTER_VALUE",
@@ -142,7 +142,7 @@ namespace {
 		static void TearDownTestCase() {}
 	};
 
-	INSTANTIATE_TEST_CASE_P(
+	INSTANTIATE_TEST_SUITE_P(
 		UseSwitchTests, UseSwitchParametrisedTests,
 		::testing::Values(
 			"SWITCH_TEMP_PV",
@@ -197,7 +197,7 @@ namespace {
 		static void TearDownTestCase() {}
 	};
 
-	INSTANTIATE_TEST_CASE_P(
+	INSTANTIATE_TEST_SUITE_P(
 		UseMagnetTempTests, UseMagnetTempParametrisedTests,
 		::testing::Values(
 			"MAGNET_TEMP_PV",
@@ -240,7 +240,7 @@ namespace {
 		static void TearDownTestCase() {}
 	};
 
-	INSTANTIATE_TEST_CASE_P(
+	INSTANTIATE_TEST_SUITE_P(
 		CompOffActTests, CompOffActParametrisedTests,
 		::testing::Values(
 			"NO_OF_COMP",

--- a/CRYOSMSApp/src/tests/CRYOSMSTests.cc
+++ b/CRYOSMSApp/src/tests/CRYOSMSTests.cc
@@ -294,7 +294,7 @@ namespace {
 	}
 	TEST_F(StartupTests, test_GIVEN_IOC_WHEN_ramp_file_valid_THEN_writes_enabled)
 	{
-		testDriver->envVarMap.at("RAMP_FILE") = "C:\\Instrument\\Apps\\EPICS\\support\\cryosms\\master\\ramps\\default.txt";
+		testDriver->envVarMap.at("RAMP_FILE") = ".\\ramps\\default.txt";
 		testDriver->checkRampFile();
 		ASSERT_EQ(testDriver->testVar, 1);
 	}


### PR DESCRIPTION
Fixes compiler errors and warnings in RHEL6 IOC build. Mostly just being more specific with some types, otherwise a bit of reordering and removing references to deprecated things.

##Acceptance criteria

- [x] code is of acceptable quality
- [x] RHEL6 build passes when built on top branch Ticket7294_fix_compiler_error (set with the latest commits on this pr)
- [x] make runtests passes
- [ ] ioctestframework tests pass