### PR TITLE
Add value to T_TO_A

### DIFF
--- a/CRYOSMSApp/src/tests/CRYOSMSTests.cc
+++ b/CRYOSMSApp/src/tests/CRYOSMSTests.cc
@@ -72,6 +72,7 @@ namespace {
 	TEST_F(StartupTests, test_GIVEN_IOC_WHEN_max_current_not_null_THEN_write_enabled)
 	{
 		testDriver->envVarMap.at("MAX_CURR") = "10.2";
+		testDriver->envVarMap.at("T_TO_A") = "1";
 		testDriver->checkMaxCurr();
 		ASSERT_EQ(testDriver->testVar, 1);
 	}


### PR DESCRIPTION
if tests done in certain order, no value for T_TO_A during the MAX_CURR tests so errors out when trying to perform unit conversion. Just putting a 1 in it fixes it.